### PR TITLE
Fix `apcsa-public` references (was `apcsa`)

### DIFF
--- a/curriculum/About.md
+++ b/curriculum/About.md
@@ -74,4 +74,4 @@ Acknowledgements
 [LICENSE.md]:  LICENSE.md
 [Locally]:     SUMMARY.md
 [On GitBook]:  https://tealsk12.gitbooks.io/ap-computer-science-a/content/
-[On GitHub]:   https://github.com/TEALSK12/apcsa/blob/master/SUMMARY.md
+[On GitHub]:   https://github.com/TEALSK12/apcsa-public/blob/master/SUMMARY.md

--- a/curriculum/CONTRIBUTING.md
+++ b/curriculum/CONTRIBUTING.md
@@ -2,8 +2,8 @@ TEALS AP CS A Curriculum — How to Contribute
 ====================================================================================================
 
 ## Repository Location
-The curriculum's source code is hosted on Github at [https://github.com/TEALSK12/apcsa]. Restricted
-instructor-only content is hosted at [https://github.com/TEALSK12/apcsa-instructor].
+The curriculum's source code is hosted on Github at [https://github.com/TEALSK12/apcsa-public].
+Restricted instructor-only content is hosted at [https://github.com/TEALSK12/apcsa-instructor].
 
 Did you catch an error in the TEALS AP CS A curriculum, or perhaps have an idea for an addition that
 would make it better? If so, we'd love to see what you've got!
@@ -94,9 +94,9 @@ Hopefully, all went well, and you've helped to make our curriculum even better -
 
 [GitHub account]:   https://github.com/join
 [Kenney Chan]:      mailto:kencha@microsoft.com
-[main code page]:   https://github.com/TEALSK12/apcsa
+[main code page]:   https://github.com/TEALSK12/apcsa-public
 [Steve Hollasch]:   mailto:steve@hollasch.net
 [style guidelines]: STYLE.md
-[submit an issue]:  https://github.com/TEALSK12/apcsa/issues
-[https://github.com/TEALSK12/apcsa]: https://github.com/TEALSK12/apcsa
+[submit an issue]:  https://github.com/TEALSK12/apcsa-public/issues
+[https://github.com/TEALSK12/apcsa-public]: https://github.com/TEALSK12/apcsa-public
 [https://github.com/TEALSK12/apcsa-instructor]: https://github.com/TEALSK12/apcsa-instructor

--- a/curriculum/Curriculum-Map.md
+++ b/curriculum/Curriculum-Map.md
@@ -32,6 +32,7 @@ Unit 1: Programming & Java (2 weeks)
 ----------------------------------------------------------------------------------------------------
 - [Unit 1 Slides]
 - [Unit 1 Word Bank]
+- [Curriculum Assets]
 
 | **LP** | **Title**                               | **In Class**   | **Reading**     | **Homework**    |
 |:-------|:----------------------------------------|:---------------|:----------------|:----------------|
@@ -141,6 +142,7 @@ Unit 2: Working with Data & Basic Control Flow (3 weeks)
 ----------------------------------------------------------------------------------------------------
 - [Unit 2 Slides]
 - [Unit 2 Word Bank]
+- [Curriculum Assets]
 
 | **LP** | **Title**                             | **In Class**   | **Reading**     | **Homework**    |
 |:-------|:--------------------------------------|:---------------|:----------------|:----------------|
@@ -280,6 +282,8 @@ Unit 3: Advanced Data & Control Flow (4 weeks)
 ----------------------------------------------------------------------------------------------------
 - [Unit 3 Slides]
 - [Unit 3 Word Bank]
+- [Curriculum Assets]
+- [Frac Calc]
 
 | **LP** | **Title**                             | **In Class**   | **Reading**     | **Homework**    |
 |:-------|:--------------------------------------|:---------------|:----------------|:----------------|
@@ -304,7 +308,7 @@ Unit 3: Advanced Data & Control Flow (4 weeks)
 | [3.17] |Finding & Fixing Errors|(Fix HW)|Review ch 3-5|Submit questions for review |
 | [3.18] |Review|(Review questions), [WS 3.18] practice test||Study |
 | 3.99 |Unit 3 test|[Test 2 Guide]<br>Test 2 Section I<br>Test 2 Section II|| |
-| 3.XX |Project: Frac Calc|[Frac Calc Student Guide]<br>[Frac Calc Teacher Guide]|| |
+| 3.XX |[Frac Calc]|[Frac Calc Student Guide]<br>[Frac Calc Teacher Guide]|| |
 
 ### 3.00
 | [Lesson 3.00]   | _Test Review & Reteach_
@@ -490,7 +494,7 @@ Unit 3: Advanced Data & Control Flow (4 weeks)
 ### 3.XX
 | Unit 3 Project  | _Frac Calc_
 |:----------------|:-----------
-| **In Class**    | [Frac Calc Student Guide]<br>[Frac Calc Teacher Guide]
+| **In Class**    | [Frac Calc]<br>[Frac Calc Student Guide]<br>[Frac Calc Teacher Guide]
 
 
 
@@ -501,6 +505,8 @@ Unit 4: Arrays, Lists, & Files (4 weeks)
 ----------------------------------------------------------------------------------------------------
 - [Unit 4 Slides]
 - [Unit 4 Word Bank]
+- [Curriculum Assets]
+- [Magpie Chatbot Lab]
 
 | **LP** | **Title**                             | **In Class**   | **Reading**     | **Homework**    |
 |:-------|:--------------------------------------|:---------------|:----------------|:----------------|
@@ -514,11 +520,11 @@ Unit 4: Arrays, Lists, & Files (4 weeks)
 | [4.06] |Nested Loop Algorithms & Rectangular Arrays|[WS 4.6]|10.1 up to Adding to and Removing from an ArrayList|SC [TBD]
 | [4.07] |ArrayList|Grudgeball<br>[Poster 4.7]||Outline ch 7 and 10.1
 | [4.08] |Finding & Fixing Errors|Fix HW|Review ch 7, 10.1 for Magpie lab|Submit questions for review
-| [4.09] 01|Magpie Lab (day 1)|Magpie Chatbot Lab Activity 1 & 2|Barrons ch 6|
-| [4.09] 02|Magpie Lab (day 2)|Magpie Chatbot Lab Activity 2|Barrons ch 6|
-| [4.09] 03|Magpie Lab (day 3)|Magpie Chatbot Lab Activity 3||Barrons ch 6 practice questions
-| [4.09] 04|Magpie Lab (day 4)|Magpie Chatbot Lab Activity 4||Check and correct Barrons ch.6 questions
-| [4.09] 05|Magpie Lab (day 5)|Magpie Chatbot Lab Activity 5||Check and correct Barrons ch.6 questions
+| [4.09] 01|[Magpie Chatbot Lab] (day&nbsp;1)|Magpie Chatbot Lab Activity 1 & 2|Barrons ch 6|
+| [4.09] 02|[Magpie Chatbot Lab] (day&nbsp;2)|Magpie Chatbot Lab Activity 2|Barrons ch 6|
+| [4.09] 03|[Magpie Chatbot Lab] (day&nbsp;3)|Magpie Chatbot Lab Activity 3||Barrons ch 6 practice questions
+| [4.09] 04|[Magpie Chatbot Lab] (day&nbsp;4)|Magpie Chatbot Lab Activity 4||Check and correct Barrons ch.6 questions
+| [4.09] 05|[Magpie Chatbot Lab] (day&nbsp;5)|Magpie Chatbot Lab Activity 5||Check and correct Barrons ch.6 questions
 | [4.10] |Review|Review questions [WS 4.10] practice test||Study
 | 4.99 |Unit 4 test|Test 3 Section I<br>Test 3 Section II||
 
@@ -617,7 +623,7 @@ Unit 4: Arrays, Lists, & Files (4 weeks)
 |:----------------|:--------------------
 | **Objectives**  | Students will complete a long-form lab, using if statements, algorithms, the Sting class, arrays, and ArrayLists.
 | **Assessments** | Students will complete the College Board’s AP CS A Magpie Chatbot Lab.<br>Students will answer assessment questions on the fourth class exam.
-| **In Class**    | Magpie Chatbot Lab Activity 1 & 2
+| **In Class**    | [Lab: Magpie Chatbot Lab]<br>Magpie Chatbot Lab Activity 1 & 2
 | **Reading**     | Barrons ch 6
 | **Homework**    |
 
@@ -680,6 +686,8 @@ Unit 5: Object-Oriented Programming (4 weeks)
 ----------------------------------------------------------------------------------------------------
 - [Unit 5 Slides]
 - [Unit 5 Word Bank]
+- [Curriculum Assets]
+- [Picture Lab]
 
 | **LP** | **Title**                             | **In Class**   | **Reading**     | **Homework**    |
 |:-------|:--------------------------------------|:---------------|:----------------|:----------------|
@@ -689,15 +697,15 @@ Unit 5: Object-Oriented Programming (4 weeks)
 | [5.03] |Object Initialization: Constructors|[WS 5.3.1]<br>[WS 5.3.2]|8.4|
 | [5.04] |Encapsulation|[WS 5.4] Mini-lessons||SC 8.22-8.28
 | [5.05] |Finding & Fixing Errors|Fix HW|Review ch 8 for Picture Lab|Submit questions for review
-| [5.06] 01|Picture Lab (day 1)|Picture Lab Activity 1 & 2<br>Picture Lab||Summarize notes since last exam
-| [5.06] 02|Picture Lab (day 2)|Picture Lab Activity 3 & 4, notebook checks||Outline ch 8
-| [5.06] 03|Picture Lab (day 3)|Picture Lab Activity 5, notebook checks|Read and highlight Barrons ch 2, skip this keyword|
-| [5.06] 04|Picture Lab (day 4)|Picture Lab Activity 5 & 6, notebook checks||Barrons ch 2 exam, skip #20
-| [5.06] 05|Picture Lab (day 5)|Picture Lab Activity 6, Barron's checks|Read and highlight Barrons ch 5|
-| [5.06] 06|Picture Lab (day 6)|Picture Lab Activity 7||SC 8.28, 8.30
-| [5.06] 07|Picture Lab (day 7)|Picture Lab Activity 8|8.5|Finish Picture Lab Activity 8
-| [5.06] 08|Picture Lab (day 8)|Picture Lab Activity 9||Cont. Picture Lab Activity 9
-| [5.06] 09|Picture Lab (day 9)|Picture Lab Activity 9, cont.||Submit questions for review
+| [5.06] 01|[Picture Lab] (day 1)|Picture Lab Activity 1 & 2<br>Picture Lab||Summarize notes since last exam
+| [5.06] 02|[Picture Lab] (day 2)|Picture Lab Activity 3 & 4, notebook checks||Outline ch 8
+| [5.06] 03|[Picture Lab] (day 3)|Picture Lab Activity 5, notebook checks|Read and highlight Barrons ch 2, skip this keyword|
+| [5.06] 04|[Picture Lab] (day 4)|Picture Lab Activity 5 & 6, notebook checks||Barrons ch 2 exam, skip #20
+| [5.06] 05|[Picture Lab] (day 5)|Picture Lab Activity 6, Barron's checks|Read and highlight Barrons ch 5|
+| [5.06] 06|[Picture Lab] (day 6)|Picture Lab Activity 7||SC 8.28, 8.30
+| [5.06] 07|[Picture Lab] (day 7)|Picture Lab Activity 8|8.5|Finish Picture Lab Activity 8
+| [5.06] 08|[Picture Lab] (day 8)|Picture Lab Activity 9||Cont. Picture Lab Activity 9
+| [5.06] 09|[Picture Lab] (day 9)|Picture Lab Activity 9, cont.||Submit questions for review
 | [5.07] |Review|Review question<br>[WS 5.7] Test practice||Study
 | [5.99]|(Unit 5 test)|Test 4 Section I<br>Test 4 Section II||
 
@@ -859,6 +867,8 @@ Unit 6: Inheritance & Polymorphism (4 weeks)
 ----------------------------------------------------------------------------------------------------
 - [Unit 6 Slides]
 - [Unit 6 Word Bank]
+- [Curriculum Assets]
+- [Text Excel]
 
 | **LP** | **Title**                             | **In Class**   | **Reading**     | **Homework**    |
 |:-------|:--------------------------------------|:---------------|:----------------|:----------------|
@@ -878,7 +888,7 @@ Unit 6: Inheritance & Polymorphism (4 weeks)
 | [6.08] |Finding & Fixing Errors|(Fix HW)|Review ch 9|Submit questions for review
 | [6.09] |Review|Review questions<br>[WS 6.5] Test practice||Study
 | 6.99 |Unit 6 test|[Test 5 Guide]<br>Test 5 Section I<br>Test 5 Section II||
-| 6.XX |Project: Text Excel|[Text Excel Student Guide A]<br>[Text Excel Student Guide B]<br>[Text Excel Student Guide C]<br>[Text Excel Teacher Guide]||
+| 6.XX |[Text Excel]|[Text Excel Student Guide A]<br>[Text Excel Student Guide B]<br>[Text Excel Student Guide C]<br>[Text Excel Teacher Guide]||
 
 ### 6.00
 | [Lesson 6.00]   | _Test Review & Reteach_
@@ -1024,7 +1034,7 @@ Unit 6: Inheritance & Polymorphism (4 weeks)
 ### 6.XX
 | Unit 6 Project  | _Text Excel_
 |:----------------|:------------
-| **In Class**    | [Text Excel Student Guide A]<br>[Text Excel Student Guide B]<br>[Text Excel Student Guide C]<br>[Text Excel Teacher Guide]
+| **In Class**    | [Text Excel]<br>[Text Excel Student Guide A]<br>[Text Excel Student Guide B]<br>[Text Excel Student Guide C]<br>[Text Excel Teacher Guide]
 
 
 
@@ -1035,28 +1045,30 @@ Unit 7: Searching & Sorting (3 weeks)
 ----------------------------------------------------------------------------------------------------
 - [Unit 7 Slides]
 - [Unit 7 Word Bank]
+- [Curriculum Assets]
+- [Elevens Lab]
 
 | **LP** | **Title**                             | **In Class**   | **Reading**     | **Homework**    |
 |:-------|:--------------------------------------|:---------------|:----------------|:----------------|
 | [7.00] |Test Review & Reteach|Review test|13.1 up to “Sorting”|Test corrections
 | [7.01] |Searching Algorithms|(CS Unplugged Battleship)<br>[WS 7.1]|13.1 “Sorting”|SC 13.4-13.6, E 13.1-13.3 
 | [7.02] |Sorting Algorithms||13.1 “Shuffling”|
-| [7.03] 01|Elevens lab (day 1)| Elevens Lab Activity 1|"13.3 skip ""Recursive Binary Search"""|SC 13.16-13.21, 13.23, 13.24
-| [7.03] 02|Elevens lab (day 2)| Elevens Lab Activity 2 (begin)||
-| [7.03] 03|Elevens lab (day 3)| Elevens Lab Activity 2 (end)||Summarize notes since last exam
-| [7.03] 04|Elevens lab (day 4)| Elevens Lab Activity 3 (begin), notebook checks||Outline ch 13
-| [7.03] 05|Elevens lab (day 5)| Elevens Lab Activity 3 (end), notebook checks|Read and outline Barrons ch 8|
-| [7.03] 06|Elevens lab (day 6)| Elevens Lab Activity 4||Barrons ch 8 exam, self-grade 
-| [7.03] 07|Elevens lab (day 7)| Elevens Lab Activity 5 (begin), Barron's checks||
-| [7.03] 08|Elevens lab (day 8)| Elevens Lab Activity 5 (end)||
-| [7.03] 09|Elevens lab (day 9)| Elevens Lab Activity 6||(Fix HW)
-| [7.03] 10|Elevens lab (day 10)| Elevens Lab Activity 7||(Fix HW)
-| [7.03] 11|Elevens lab (day 11)| Elevens Lab Activity 8, re-grade fixed HW||
-| [7.03] 12|Elevens lab (day 12)| Elevens Lab Activity 9 (begin), re-grade fixed HW||
-| [7.03] 13|Elevens lab (day 13)| Elevens Lab Activity 9 (end), re-grade fixed HW||Submit questions for review
-| [7.03] 14|Elevens lab (day 14)| Elevens Lab Activity 10, re-grade fixed HW||
-| [7.03] 15|Elevens lab (day 15)| Elevens Lab Activity 11 (begin)||
-| [7.03] 16|Elevens lab (day 16)| Elevens Lab Activity 11 (end)||
+| [7.03] 01|[Elevens Lab] (day 1)| Elevens Lab Activity 1|"13.3 skip ""Recursive Binary Search"""|SC 13.16-13.21, 13.23, 13.24
+| [7.03] 02|[Elevens Lab] (day 2)| Elevens Lab Activity 2 (begin)||
+| [7.03] 03|[Elevens Lab] (day 3)| Elevens Lab Activity 2 (end)||Summarize notes since last exam
+| [7.03] 04|[Elevens Lab] (day 4)| Elevens Lab Activity 3 (begin), notebook checks||Outline ch 13
+| [7.03] 05|[Elevens Lab] (day 5)| Elevens Lab Activity 3 (end), notebook checks|Read and outline Barrons ch 8|
+| [7.03] 06|[Elevens Lab] (day 6)| Elevens Lab Activity 4||Barrons ch 8 exam, self-grade 
+| [7.03] 07|[Elevens Lab] (day 7)| Elevens Lab Activity 5 (begin), Barron's checks||
+| [7.03] 08|[Elevens Lab] (day 8)| Elevens Lab Activity 5 (end)||
+| [7.03] 09|[Elevens Lab] (day 9)| Elevens Lab Activity 6||(Fix HW)
+| [7.03] 10|[Elevens Lab] (day 10)| Elevens Lab Activity 7||(Fix HW)
+| [7.03] 11|[Elevens Lab] (day 11)| Elevens Lab Activity 8, re-grade fixed HW||
+| [7.03] 12|[Elevens Lab] (day 12)| Elevens Lab Activity 9 (begin), re-grade fixed HW||
+| [7.03] 13|[Elevens Lab] (day 13)| Elevens Lab Activity 9 (end), re-grade fixed HW||Submit questions for review
+| [7.03] 14|[Elevens Lab] (day 14)| Elevens Lab Activity 10, re-grade fixed HW||
+| [7.03] 15|[Elevens Lab] (day 15)| Elevens Lab Activity 11 (begin)||
+| [7.03] 16|[Elevens Lab] (day 16)| Elevens Lab Activity 11 (end)||
 | [7.04]|Review|Review questions||Study
 | 7.99|Unit 7 test|[Test 6 Guide]<br>Test 6 Section I<br>Test 6 Section II||
 
@@ -1255,6 +1267,7 @@ Unit 8: Recursion (2 weeks)
 ----------------------------------------------------------------------------------------------------
 - [Unit 8 Slides]
 - [Unit 8 Word Bank]
+- [Curriculum Assets]
 
 | **LP** | **Title**                             | **In Class**   | **Reading**     | **Homework**    |
 |:-------|:--------------------------------------|:---------------|:----------------|:----------------|
@@ -1352,6 +1365,8 @@ Unit 8: Recursion (2 weeks)
 ----------------------------------------------------------------------------------------------------
 Unit 9: AP Test Review (3 weeks)
 ----------------------------------------------------------------------------------------------------
+
+- [Curriculum Assets]
 
 ### 9.00
 | [Lesson 9.00]   | _Reviewing for the AP Exam_
@@ -1549,7 +1564,12 @@ self-contained website with lessons, labs and other supporting resources:
 [8.07]: Unit8/Lesson-807.md
 [Lesson 9.00]: Unit9/Lesson-900.md
 [9.00]: Unit9/Lesson-900.md
+[Curriculum Assets]: Assets.md
+[Elevens Lab]: Assets.md#elevens
+[Frac Calc]: Assets.md#fraccalc
+[Magpie Chatbot Lab]: Assets.md#magpie
 [Operator Precedence]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Operator%20Precedence.pptx
+[Picture Lab]: Assets.md#picturelab
 [Poster 2.4]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/Poster%202.4.docx
 [Poster 3.16.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Poster%203.16.1.pdf
 [Poster 3.16.2]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Poster%203.16.2.pdf
@@ -1563,6 +1583,7 @@ self-contained website with lessons, labs and other supporting resources:
 [Test 2 Guide]: Unit3/Test-2-Guide.md
 [Test 5 Guide]: Unit6/Test-5-Guide.md
 [Test 6 Guide]: Unit7/Test-6-Guide.md
+[Text Excel]: Assets.md#textexcel
 [Text Excel Student Guide A]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Text%20Excel%20A%20Student%20Guide.docx
 [Text Excel Student Guide B]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Text%20Excel%20B%20Student%20Guide.docx
 [Text Excel Student Guide C]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Text%20Excel%20C%20Student%20Guide.docx

--- a/curriculum/Curriculum-Map.md
+++ b/curriculum/Curriculum-Map.md
@@ -1377,12 +1377,12 @@ self-contained website with lessons, labs and other supporting resources:
 
 
 
-[Algorithm for Solving Problems]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/Algorithm%20for%20Solving%20Problems.docx
-[DeMorgan’s Law]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/DeMorgan%27s%20Law.pptx
-[Equestria]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/Map%20of%20Equestria.pptx
-[Example 6.1]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/Example%206.1.jpg
-[Frac Calc Student Guide]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/Frac%20Calc%20Student%20Guide.docx
-[Frac Calc Teacher Guide]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/Frac%20Calc%20Teacher%20Guide.docx
+[Algorithm for Solving Problems]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Algorithm%20for%20Solving%20Problems.docx
+[DeMorgan’s Law]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/DeMorgan%27s%20Law.pptx
+[Equestria]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Map%20of%20Equestria.pptx
+[Example 6.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Example%206.1.jpg
+[Frac Calc Student Guide]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Frac%20Calc%20Student%20Guide.docx
+[Frac Calc Teacher Guide]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Frac%20Calc%20Teacher%20Guide.docx
 [Lesson 1.01]: Unit1/Lesson-101.md
 [1.01]: Unit1/Lesson-101.md
 [Lesson 1.02]: Unit1/Lesson-102.md
@@ -1549,76 +1549,76 @@ self-contained website with lessons, labs and other supporting resources:
 [8.07]: Unit8/Lesson-807.md
 [Lesson 9.00]: Unit9/Lesson-900.md
 [9.00]: Unit9/Lesson-900.md
-[Operator Precedence]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/Operator%20Precedence.pptx
-[Poster 2.4]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/Poster%202.4.docx
-[Poster 3.16.1]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/Poster%203.16.1.pdf
-[Poster 3.16.2]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/Poster%203.16.2.pdf
-[Poster 4.1]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/Poster%204.1.pptx
-[Poster 4.2]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/Poster%204.2.pptx
-[Poster 4.7]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/Poster%204.7.pptx
-[Poster 6.3]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/Poster%206.3.pptx
-[Poster 6.6]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/Poster%206.6.pptx
-[Quiz 8.5]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit8/Quiz%208.5.docx
-[Teacher Demo 8.3]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit8/Teacher%20Demo%208.3.docx
+[Operator Precedence]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Operator%20Precedence.pptx
+[Poster 2.4]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/Poster%202.4.docx
+[Poster 3.16.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Poster%203.16.1.pdf
+[Poster 3.16.2]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Poster%203.16.2.pdf
+[Poster 4.1]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/Poster%204.1.pptx
+[Poster 4.2]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/Poster%204.2.pptx
+[Poster 4.7]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/Poster%204.7.pptx
+[Poster 6.3]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Poster%206.3.pptx
+[Poster 6.6]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Poster%206.6.pptx
+[Quiz 8.5]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit8/Quiz%208.5.docx
+[Teacher Demo 8.3]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit8/Teacher%20Demo%208.3.docx
 [Test 2 Guide]: Unit3/Test-2-Guide.md
 [Test 5 Guide]: Unit6/Test-5-Guide.md
 [Test 6 Guide]: Unit7/Test-6-Guide.md
-[Text Excel Student Guide A]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/Text%20Excel%20A%20Student%20Guide.docx
-[Text Excel Student Guide B]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/Text%20Excel%20B%20Student%20Guide.docx
-[Text Excel Student Guide C]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/Text%20Excel%20C%20Student%20Guide.docx
-[Text Excel Teacher Guide]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/Text%20Excel%20Teacher%20Guide.docx
-[Unit 1 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit1/Unit1.pptx
-[Unit 1 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit1/Unit%201%20Word%20Bank.docx
-[Unit 2 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/Unit2.pptx
-[Unit 2 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/Unit%202%20Word%20Bank.docx
-[Unit 3 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/Unit3.pptx
-[Unit 3 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/Unit%302%20Word%20Bank.docx
-[Unit 4 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/Unit4.pptx
-[Unit 4 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/Unit%402%20Word%20Bank.docx
-[Unit 5 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit5/Unit5.pptx
-[Unit 5 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit5/Unit%502%20Word%20Bank.docx
-[Unit 6 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/Unit6.pptx
-[Unit 6 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/Unit%602%20Word%20Bank.docx
-[Unit 7 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit7/Unit7.pptx
-[Unit 7 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit7/Unit%702%20Word%20Bank.docx
-[Unit 8 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit8/Unit8.pptx
-[Unit 8 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit8/Unit%802%20Word%20Bank.docx
-[WS 1.1.1]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit1/WS%201.1.1.docx
-[WS 1.1.2]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit1/WS%201.1.2.docx
-[WS 1.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit1/WS%201.4.docx
-[WS 1.9]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit1/WS%201.9.docx
-[WS 2.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/WS%202.1.docx
-[WS 2.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/WS%202.2.docx
-[WS 2.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/WS%202.4.docx
-[WS 2.5]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/WS%202.5.docx
-[WS 2.7]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/WS%202.7.docx
-[WS 2.11]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/WS%202.11.docx
-[WS 3.10]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.10.docx
-[WS 3.12]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.12.docx
-[WS 3.13]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.13.docx
-[WS 3.15]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.15.docx
-[WS 3.16]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.16.docx
-[WS 3.18]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.18.docx
-[WS 3.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.4.docx
-[WS 3.5]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.5.docx
-[WS 3.7]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.7.docx
-[WS 4.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/WS%204.1.docx
-[WS 4.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/WS%204.2.docx
-[WS 4.3]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/WS%204.3.docx
-[WS 4.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/WS%204.4.docx
-[WS 4.6]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/WS%204.6.docx
-[WS 4.10]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/WS%204.10.docx
-[WS 5.1.1]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit5/WS%205.1.1.pdf
-[WS 5.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit5/WS%205.2.docx
-[WS 5.3.1]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit5/WS%205.3.1.docx
-[WS 5.3.2]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit5/WS%205.3.2.docx
-[WS 5.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit5/WS%205.4.docx
-[WS 5.7]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit5/WS%205.7.docx
-[WS 6.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/WS%206.1.docx
-[WS 6.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/WS%206.2.docx
-[WS 6.3]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/WS%206.3.docx
-[WS 6.4.1]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/WS%206.4.1.docx
-[WS 6.4.2]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/WS%206.4.2.docx
-[WS 6.5]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/WS%206.5.docx
-[WS 7.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit7/WS%207.1.docx
-[WS 8.3]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit8/WS%208.3.docx
+[Text Excel Student Guide A]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Text%20Excel%20A%20Student%20Guide.docx
+[Text Excel Student Guide B]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Text%20Excel%20B%20Student%20Guide.docx
+[Text Excel Student Guide C]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Text%20Excel%20C%20Student%20Guide.docx
+[Text Excel Teacher Guide]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Text%20Excel%20Teacher%20Guide.docx
+[Unit 1 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit1/Unit1.pptx
+[Unit 1 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit1/Unit%201%20Word%20Bank.docx
+[Unit 2 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/Unit2.pptx
+[Unit 2 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/Unit%202%20Word%20Bank.docx
+[Unit 3 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Unit3.pptx
+[Unit 3 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Unit%302%20Word%20Bank.docx
+[Unit 4 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/Unit4.pptx
+[Unit 4 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/Unit%402%20Word%20Bank.docx
+[Unit 5 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/Unit5.pptx
+[Unit 5 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/Unit%502%20Word%20Bank.docx
+[Unit 6 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Unit6.pptx
+[Unit 6 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Unit%602%20Word%20Bank.docx
+[Unit 7 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit7/Unit7.pptx
+[Unit 7 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit7/Unit%702%20Word%20Bank.docx
+[Unit 8 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit8/Unit8.pptx
+[Unit 8 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit8/Unit%802%20Word%20Bank.docx
+[WS 1.1.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit1/WS%201.1.1.docx
+[WS 1.1.2]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit1/WS%201.1.2.docx
+[WS 1.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit1/WS%201.4.docx
+[WS 1.9]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit1/WS%201.9.docx
+[WS 2.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/WS%202.1.docx
+[WS 2.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/WS%202.2.docx
+[WS 2.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/WS%202.4.docx
+[WS 2.5]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/WS%202.5.docx
+[WS 2.7]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/WS%202.7.docx
+[WS 2.11]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/WS%202.11.docx
+[WS 3.10]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.10.docx
+[WS 3.12]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.12.docx
+[WS 3.13]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.13.docx
+[WS 3.15]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.15.docx
+[WS 3.16]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.16.docx
+[WS 3.18]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.18.docx
+[WS 3.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.4.docx
+[WS 3.5]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.5.docx
+[WS 3.7]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.7.docx
+[WS 4.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/WS%204.1.docx
+[WS 4.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/WS%204.2.docx
+[WS 4.3]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/WS%204.3.docx
+[WS 4.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/WS%204.4.docx
+[WS 4.6]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/WS%204.6.docx
+[WS 4.10]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/WS%204.10.docx
+[WS 5.1.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/WS%205.1.1.pdf
+[WS 5.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/WS%205.2.docx
+[WS 5.3.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/WS%205.3.1.docx
+[WS 5.3.2]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/WS%205.3.2.docx
+[WS 5.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/WS%205.4.docx
+[WS 5.7]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/WS%205.7.docx
+[WS 6.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/WS%206.1.docx
+[WS 6.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/WS%206.2.docx
+[WS 6.3]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/WS%206.3.docx
+[WS 6.4.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/WS%206.4.1.docx
+[WS 6.4.2]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/WS%206.4.2.docx
+[WS 6.5]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/WS%206.5.docx
+[WS 7.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit7/WS%207.1.docx
+[WS 8.3]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit8/WS%208.3.docx

--- a/curriculum/Unit1/Lesson-101.md
+++ b/curriculum/Unit1/Lesson-101.md
@@ -165,5 +165,5 @@ Forum discussion
 [Lesson 1.01 Using Eclipse & Practice-it (TEALS Discourse account required)](http://forums.tealsk12.org/c/ap-cs-a-unit-1/1-01-using-eclipse-practice-it)
 
 
-[WS 1.1.1]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit1/WS%201.1.1.docx
-[WS 1.1.2]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit1/WS%201.1.2.docx
+[WS 1.1.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit1/WS%201.1.1.docx
+[WS 1.1.2]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit1/WS%201.1.2.docx

--- a/curriculum/Unit1/Lesson-104.md
+++ b/curriculum/Unit1/Lesson-104.md
@@ -221,4 +221,4 @@ Forum discussion
 [Lesson 1.04 Common Errors & Comments (TEALS Discourse account required)](http://forums.tealsk12.org/c/ap-cs-a-unit-1/1-04-common-errors-comments)
 
 
-[WS 1.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit1/WS%201.4.docx
+[WS 1.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit1/WS%201.4.docx

--- a/curriculum/Unit1/Lesson-109.md
+++ b/curriculum/Unit1/Lesson-109.md
@@ -100,4 +100,4 @@ Forum discussion
 [Lesson 1.09 Unit 1 Test (TEALS Discourse account required)](http://forums.tealsk12.org/c/ap-cs-a-unit-1/1-99-unit-1-test)
 
 
-[WS 1.9]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit1/WS%201.9.docx
+[WS 1.9]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit1/WS%201.9.docx

--- a/curriculum/Unit2/Lesson-201.md
+++ b/curriculum/Unit2/Lesson-201.md
@@ -183,4 +183,4 @@ Forum discussion
 [Lesson 2.01 Basic Data Concepts (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-2/2-01-basic-data-concepts)
 
 
-[WS 2.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/WS%202.1.docx
+[WS 2.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/WS%202.1.docx

--- a/curriculum/Unit2/Lesson-202.md
+++ b/curriculum/Unit2/Lesson-202.md
@@ -183,4 +183,4 @@ Forum discussion
 [Lesson 2.02 Declaring and Assigning Variables (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-2/2-02-declaring-assigning-variables)
 
 
-[WS 2.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/WS%202.2.docx
+[WS 2.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/WS%202.2.docx

--- a/curriculum/Unit2/Lesson-204.md
+++ b/curriculum/Unit2/Lesson-204.md
@@ -170,5 +170,5 @@ Forum discussion
 [Lesson 2.04 Mixing Types & Casting (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-2/2-04-mixing-types-casting)
 
 
-[WS 2.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/WS%202.4.docx
-[Poster 2.4]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/Poster%202.4.docx
+[WS 2.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/WS%202.4.docx
+[Poster 2.4]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/Poster%202.4.docx

--- a/curriculum/Unit2/Lesson-205.md
+++ b/curriculum/Unit2/Lesson-205.md
@@ -188,4 +188,4 @@ Forum discussion
 [Lesson 2.05 for Loops (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-2/2-05-for-loops)
 
 
-[WS 2.5]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/WS%202.5.docx
+[WS 2.5]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/WS%202.5.docx

--- a/curriculum/Unit2/Lesson-207.md
+++ b/curriculum/Unit2/Lesson-207.md
@@ -130,4 +130,4 @@ Forum discussion
 [Lesson 2.07 Scope & Pseudocode (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-2/2-07-scope-pseudocode)
 
 
-[WS 2.7]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/WS%202.7.docx
+[WS 2.7]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/WS%202.7.docx

--- a/curriculum/Unit2/Lesson-211.md
+++ b/curriculum/Unit2/Lesson-211.md
@@ -99,4 +99,4 @@ Forum discussion
 [Lesson 2.11 Unit 2 Review (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-2/2-11-review)
 
 
-[WS 2.11]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit2/WS%202.11.docx
+[WS 2.11]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/WS%202.11.docx

--- a/curriculum/Unit3/Lesson-304.md
+++ b/curriculum/Unit3/Lesson-304.md
@@ -146,5 +146,5 @@ Forum discussion
 [Lesson 3.04 Programming Project (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-3/3-04-programming-project)
 
 
-[WS 3.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.4.docx
-[Equestria]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/Map%20of%20Equestria.pptx
+[WS 3.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.4.docx
+[Equestria]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Map%20of%20Equestria.pptx

--- a/curriculum/Unit3/Lesson-305.md
+++ b/curriculum/Unit3/Lesson-305.md
@@ -180,4 +180,4 @@ Forum discussion
 [Lesson 3.05 Using Objects & String Processing (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-3/3-05-using-objects-string-processing)
 
 
-[WS 3.5]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.5.docx
+[WS 3.5]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.5.docx

--- a/curriculum/Unit3/Lesson-307.md
+++ b/curriculum/Unit3/Lesson-307.md
@@ -169,4 +169,4 @@ Forum discussion
 [Lesson 3.07 Pokémon Battle Programming Project (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-3/3-07-pokemon-battle-programming-project)
 
 
-[WS 3.7]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.7.docx
+[WS 3.7]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.7.docx

--- a/curriculum/Unit3/Lesson-309.md
+++ b/curriculum/Unit3/Lesson-309.md
@@ -338,4 +338,4 @@ Forum discussion
 [Lesson 3.09 Relational Operators & if/else (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-3/3-09-relational-operators-if-else)
 
   
-[Operator Precedence]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/Operator%20Precedence.pptx
+[Operator Precedence]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Operator%20Precedence.pptx

--- a/curriculum/Unit3/Lesson-310.md
+++ b/curriculum/Unit3/Lesson-310.md
@@ -79,4 +79,4 @@ Forum discussion
 [Lesson 3.10 Nested if/else Statements (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-3/3-10-nested-if-else-statements)
 
 
-[WS 3.10]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.10.docx
+[WS 3.10]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.10.docx

--- a/curriculum/Unit3/Lesson-312.md
+++ b/curriculum/Unit3/Lesson-312.md
@@ -247,4 +247,4 @@ Forum discussion
 [Lesson 3.12 Cumulative Algorithms (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-3/3-12-cumulative-algorithms)
 
 
-[WS 3.12]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.12.docx
+[WS 3.12]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.12.docx

--- a/curriculum/Unit3/Lesson-313.md
+++ b/curriculum/Unit3/Lesson-313.md
@@ -118,7 +118,7 @@ Common Mistakes
 Loops common mistakes:
 <http://interactivepython.org/runestone/static/JavaReview/LoopBasics/lMistakes.html>
 
-[WS 3.13]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.13.docx
+[WS 3.13]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.13.docx
 
 
 Video

--- a/curriculum/Unit3/Lesson-315.md
+++ b/curriculum/Unit3/Lesson-315.md
@@ -136,4 +136,4 @@ Forum discussion
 [Lesson 3.15 Fencepost & Sentinel Loops (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-3/3-15-fencepost-sentinel-loops)
 
 
-[WS 3.15]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.15.docx
+[WS 3.15]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.15.docx

--- a/curriculum/Unit3/Lesson-316.md
+++ b/curriculum/Unit3/Lesson-316.md
@@ -290,7 +290,7 @@ Forum discussion
 [Lesson 3.16 Boolean Logic (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-3/3-1601-1602-boolean-logic)  
 
 
-[WS 3.16]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.16.docx
-[Poster 3.16.1]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/Poster%203.16.1.pdf
-[Poster 3.16.2]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/Poster%203.16.2.pdf
-[DeMorgan’s Law]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/DeMorgan%27s%20Law.pptx
+[WS 3.16]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.16.docx
+[Poster 3.16.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Poster%203.16.1.pdf
+[Poster 3.16.2]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Poster%203.16.2.pdf
+[DeMorgan’s Law]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/DeMorgan%27s%20Law.pptx

--- a/curriculum/Unit3/Lesson-318.md
+++ b/curriculum/Unit3/Lesson-318.md
@@ -99,4 +99,4 @@ Forum discussion
 [Lesson 3.18 Review (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-3/3-18-review)
 
 
-[WS 3.18]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit3/WS%203.18.docx
+[WS 3.18]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.18.docx

--- a/curriculum/Unit4/Lesson-401.md
+++ b/curriculum/Unit4/Lesson-401.md
@@ -251,5 +251,5 @@ Forum discussion
 [Lesson 4.01 Array Basics (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-4/4-01-array-basics)
 
 
-[WS 4.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/WS%204.1.docx
-[Poster 4.2]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/Poster%204.2.pptx
+[WS 4.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/WS%204.1.docx
+[Poster 4.2]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/Poster%204.2.pptx

--- a/curriculum/Unit4/Lesson-402.md
+++ b/curriculum/Unit4/Lesson-402.md
@@ -155,4 +155,4 @@ Forum discussion
 [Lesson 4.02 For-Each Loop & Arrays Class (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-4/4-02-for-each-loop-arrays-class)
 
 
-[WS 4.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/WS%204.2.docx
+[WS 4.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/WS%204.2.docx

--- a/curriculum/Unit4/Lesson-403.md
+++ b/curriculum/Unit4/Lesson-403.md
@@ -236,4 +236,4 @@ Forum discussion
 [Lesson 4.03 Printing, Searching, & Testing for Equality (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-4/4-03-printing-searching-testing-for-equality)
 
 
-[WS 4.3]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/WS%204.3.docx
+[WS 4.3]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/WS%204.3.docx

--- a/curriculum/Unit4/Lesson-404.md
+++ b/curriculum/Unit4/Lesson-404.md
@@ -129,4 +129,4 @@ Forum discussion
 [Lesson 4.04 Reference Semantics (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-4/4-04-reference-semantics)
 
 
-[WS 4.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/WS%204.4.docx
+[WS 4.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/WS%204.4.docx

--- a/curriculum/Unit4/Lesson-406.md
+++ b/curriculum/Unit4/Lesson-406.md
@@ -260,4 +260,4 @@ Forum discussion
 [Lesson 4.06 Nested Loop Algorithms & Rectangular Arrays (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-4/4-06-nested-loop-algorithms-rectangular-arrays)
 
 
-[WS 4.6]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/WS%204.6.docx
+[WS 4.6]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/WS%204.6.docx

--- a/curriculum/Unit4/Lesson-407.md
+++ b/curriculum/Unit4/Lesson-407.md
@@ -277,4 +277,4 @@ Forum discussion
 [Lesson 4.07 ArrayList (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-4/4-07-arraylist)
 
 
-[Poster 4.7]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/Poster%204.7.pptx
+[Poster 4.7]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/Poster%204.7.pptx

--- a/curriculum/Unit4/Lesson-410.md
+++ b/curriculum/Unit4/Lesson-410.md
@@ -76,4 +76,4 @@ Forum discussion
 [Lesson 4.10 Unit 4 Review (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-4/4-1-review)
 
 
-[WS 4.10]:  https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit4/WS%204.10.docx
+[WS 4.10]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/WS%204.10.docx

--- a/curriculum/Unit5/Lesson-501.md
+++ b/curriculum/Unit5/Lesson-501.md
@@ -358,4 +358,4 @@ Forum discussion
 [Lesson 5.01 Object Oriented Programming (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-5/5-01-object-oriented-programming)
 
 
-[WS 5.1.1]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit5/WS%205.1.1.pdf
+[WS 5.1.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/WS%205.1.1.pdf

--- a/curriculum/Unit5/Lesson-502.md
+++ b/curriculum/Unit5/Lesson-502.md
@@ -291,4 +291,4 @@ Forum discussion
 [Lesson 5.02 Object State & Behavior (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-5/5-02-object-state-behavior)
 
 
-[WS 5.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit5/WS%205.2.docx
+[WS 5.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/WS%205.2.docx

--- a/curriculum/Unit5/Lesson-503.md
+++ b/curriculum/Unit5/Lesson-503.md
@@ -238,5 +238,5 @@ Forum discussion
 [Lesson 5.03 Object Initialization: Constructors (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-5/5-03-object-initialization-constructors)
 
 
-[WS 5.3.1]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit5/WS%205.3.1.docx
-[WS 5.3.2]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit5/WS%205.3.2.docx
+[WS 5.3.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/WS%205.3.1.docx
+[WS 5.3.2]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/WS%205.3.2.docx

--- a/curriculum/Unit5/Lesson-504.md
+++ b/curriculum/Unit5/Lesson-504.md
@@ -218,4 +218,4 @@ Forum discussion
 [Lesson 5.04 Encapsulation (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-5/5-04-encapsulation)
 
 
-[WS 5.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit5/WS%205.4.docx
+[WS 5.4]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/WS%205.4.docx

--- a/curriculum/Unit5/Lesson-507.md
+++ b/curriculum/Unit5/Lesson-507.md
@@ -75,4 +75,4 @@ Forum discussion
 [Lesson 5.0 Unit 5 Review (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-5/5-07-review)
 
 
-[WS 5.7]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit5/WS%205.7.docx
+[WS 5.7]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/WS%205.7.docx

--- a/curriculum/Unit6/Lesson-601.md
+++ b/curriculum/Unit6/Lesson-601.md
@@ -346,5 +346,5 @@ Forum discussion
 [Lesson 6.01 Inheritance Basics (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-6/6-0101-0102-inheritance-basics)
 
 
-[WS 6.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/WS%206.1.docx
-[Example 6.1]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/Example%206.1.jpg
+[WS 6.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/WS%206.1.docx
+[Example 6.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Example%206.1.jpg

--- a/curriculum/Unit6/Lesson-602.md
+++ b/curriculum/Unit6/Lesson-602.md
@@ -211,4 +211,4 @@ Forum discussion
 [Lesson 6.02 Overriding Methods & Accessing Inherited Code (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-6/6-02-overriding-methods-accessing-inherited-code)
 
 
-[WS 6.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/WS%206.2.docx
+[WS 6.2]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/WS%206.2.docx

--- a/curriculum/Unit6/Lesson-603.md
+++ b/curriculum/Unit6/Lesson-603.md
@@ -171,5 +171,5 @@ Forum discussion
 [Lesson 6.03 Interacting with the Object Superclass (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-6/6-03-interacting-with-the-object-superclass)
 
 
-[WS 6.3]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/WS%206.3.docx
-[Poster 6.3]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/Poster%206.3.pptx
+[WS 6.3]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/WS%206.3.docx
+[Poster 6.3]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Poster%206.3.pptx

--- a/curriculum/Unit6/Lesson-604.md
+++ b/curriculum/Unit6/Lesson-604.md
@@ -232,5 +232,5 @@ Forum discussion
 [Lesson 6.04 Polymorphism (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-6/6-04-polymorphism)
 
 
-[WS 6.4.1]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/WS%206.4.1.docx
-[WS 6.4.2]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/WS%206.4.2.docx
+[WS 6.4.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/WS%206.4.1.docx
+[WS 6.4.2]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/WS%206.4.2.docx

--- a/curriculum/Unit6/Lesson-605.md
+++ b/curriculum/Unit6/Lesson-605.md
@@ -188,4 +188,4 @@ Forum discussion
 [Lesson 6.05 Has-a Relationships (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-6/6-05-has-a-relationships)
 
 
-[WS 6.5]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/WS%206.5.docx
+[WS 6.5]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/WS%206.5.docx

--- a/curriculum/Unit6/Lesson-606.md
+++ b/curriculum/Unit6/Lesson-606.md
@@ -212,4 +212,4 @@ Forum discussion
 [Lesson 6.06 Interfaces (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-6/6-06-interfaces)
 
 
-[Poster 6.6]:    https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit6/Poster%206.6.pptx
+[Poster 6.6]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Poster%206.6.pptx

--- a/curriculum/Unit7/Lesson-701.md
+++ b/curriculum/Unit7/Lesson-701.md
@@ -160,4 +160,4 @@ Forum discussion
 [Lesson 7.01 Searching Algorithms (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-7/7-01-searching-algorithms)
 
 
-[WS 7.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit7/WS%207.1.docx
+[WS 7.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit7/WS%207.1.docx

--- a/curriculum/Unit8/Lesson-803.md
+++ b/curriculum/Unit8/Lesson-803.md
@@ -272,5 +272,5 @@ Forum discussion
 [Lesson 8.03 Mechanics of Recursion (TEALS Discourse account required)](http://forums.tealsk12.org/c/unit-8/8-03-mechanics-of-recursion)
 
 
-[WS 8.3]:   https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit8/WS%208.3.docx
-[Teacher Demo 8.3]: https://raw.githubusercontent.com/TEALSK12/apcsa/master/curriculum/Unit8/Teacher%20Demo%208.3.docx
+[WS 8.3]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit8/WS%208.3.docx
+[Teacher Demo 8.3]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit8/Teacher%20Demo%208.3.docx


### PR DESCRIPTION
Prep for immediate release: fix all individual component references to the old `apcsa` repo (now named `apcsa-public`.