### PR TITLE
Update links to Gil Lund's Eclipse IDE videos

### DIFF
--- a/curriculum/README.md
+++ b/curriculum/README.md
@@ -23,9 +23,11 @@ the past, students who are gifted/talented, students who are otherwise “outsid
 Accessing the Curriculum
 ------------------------
 
-The AP Computer Science A Curriculum GitBook is located at [https://www.gitbook.com/book/tealsk12/ap-computer-science-a/details](https://www.gitbook.com/book/tealsk12/ap-computer-science-a/details)
+The AP Computer Science A Curriculum GitBook is located at
+https://www.gitbook.com/book/tealsk12/ap-computer-science-a/details.
 
-For contributions to the curriculum, the AP Computer Science A GitHub repository is located at [https://github.com/TEALSK12/apcsa](https://github.com/TEALSK12/apcsa)
+For contributions to the curriculum, the AP Computer Science A GitHub repository is located at
+https://github.com/TEALSK12/apcsa.
 
 Using the curriculum
 --------------------
@@ -189,8 +191,12 @@ Digital Tools Associated with This Curriculum
 
 Coding in Java requires the Java Development Kit and a text editor or IDE. There are many Java IDEs
 available; at present time, most of the TEALS classrooms use Eclipse. Unit 1 includes directions for
-installing Eclipse. TEALS volunteer Gil Lund has prepared a video with a Hello World and walkthrough
-of some Eclipse: https://mix.office.com/watch/pje5izaj92jz/.
+installing Eclipse.
+
+TEALS volunteer Gil Lund has prepared two videos as an introduction to Eclipse you may find useful:
+
+  1. [Intro to Eclipse / Java Debugging Part 1: Perspectives]
+  2. [Intro to Eclipse / Java Debugging Part 2: Breakpoints]
 
 ### Practice-It!
 
@@ -225,7 +231,7 @@ encouraged to email the program's creator Alex Aiken directly, at
 
 
 ### Additional Resources
---------------------
+------------------------
 
 - The free web-based game Code Hunt (http://www.codehunt.com) offers opportunities for students to
   find and fix errors by “discovering the missing code segments.” Assignments/Levels are
@@ -291,9 +297,11 @@ on the TEALS dashboard, or to [APSquad@tealsk12.org](mailto:APSquad@tealsk12.org
 
 [20 Fun Free Tools for Interactive Classroom Collaboration]: http://tinyurl.com/k62tstg
 [AP Java Quick Reference]: http://apcentral.collegeboard.com/apc/public/repository/ap_comp_sci_a_quick_reference.pdf
-[Curriculum Map]: Curriculum-Map.md
+[Curriculum Map]: ./Curriculum-Map.md
 [Google Hangouts]: http://hangouts.google.com
 [Grudgeball]: https://www.youtube.com/watch?v=u_GzWwSrDlo
+[Intro to Eclipse / Java Debugging Part 1: Perspectives]: https://www.youtube.com/watch?v=xqhNBmJ7XV4
+[Intro to Eclipse / Java Debugging Part 2: Breakpoints]: https://www.youtube.com/watch?v=Qq2nUrgsxwk
 [Parson's Problems]: https://www.youtube.com/watch?v=11n-AsaCd9w
 [Practice-It]: https://practiceit.cs.washington.edu/
 [Projects and Labs]: https://www.youtube.com/watch?v=WHvuK7LBe-o

--- a/curriculum/README.md
+++ b/curriculum/README.md
@@ -190,13 +190,8 @@ Digital Tools Associated with This Curriculum
 ### Integrated Design Environment (IDE) — Eclipse
 
 Coding in Java requires the Java Development Kit and a text editor or IDE. There are many Java IDEs
-available; at present time, most of the TEALS classrooms use Eclipse. Unit 1 includes directions for
+available. Currently most of the TEALS classrooms use Eclipse. Unit 1 includes directions for
 installing Eclipse.
-
-TEALS volunteer Gil Lund has prepared two videos as an introduction to Eclipse you may find useful:
-
-  1. [Intro to Eclipse / Java Debugging Part 1: Perspectives]
-  2. [Intro to Eclipse / Java Debugging Part 2: Breakpoints]
 
 ### Practice-It!
 
@@ -300,8 +295,6 @@ on the TEALS dashboard, or to [APSquad@tealsk12.org](mailto:APSquad@tealsk12.org
 [Curriculum Map]: ./Curriculum-Map.md
 [Google Hangouts]: http://hangouts.google.com
 [Grudgeball]: https://www.youtube.com/watch?v=u_GzWwSrDlo
-[Intro to Eclipse / Java Debugging Part 1: Perspectives]: https://www.youtube.com/watch?v=xqhNBmJ7XV4
-[Intro to Eclipse / Java Debugging Part 2: Breakpoints]: https://www.youtube.com/watch?v=Qq2nUrgsxwk
 [Parson's Problems]: https://www.youtube.com/watch?v=11n-AsaCd9w
 [Practice-It]: https://practiceit.cs.washington.edu/
 [Projects and Labs]: https://www.youtube.com/watch?v=WHvuK7LBe-o


### PR DESCRIPTION
The old one was on Office Mix, which has been discontinued. The two new
ones in this change introduce Eclipse, but they may not be identical to
the old one. However, they do introduce Eclipse and using the debugger.

Fixes #81