### PR TITLE
Fix current directory links for GitBook

### DIFF
--- a/curriculum/Unit1/Unit1-Map.md
+++ b/curriculum/Unit1/Unit1-Map.md
@@ -117,26 +117,26 @@ classroom.
 
 
 
-[1.01]: ./Lesson-101.md
-[1.02]: ./Lesson-102.md
-[1.03]: ./Lesson-103.md
-[1.04]: ./Lesson-104.md
-[1.05]: ./Lesson-105.md
-[1.06]: ./Lesson-106.md
-[1.07]: ./Lesson-107.md
-[1.08]: ./Lesson-108.md
-[1.09]: ./Lesson-109.md
+[1.01]: Lesson-101.md
+[1.02]: Lesson-102.md
+[1.03]: Lesson-103.md
+[1.04]: Lesson-104.md
+[1.05]: Lesson-105.md
+[1.06]: Lesson-106.md
+[1.07]: Lesson-107.md
+[1.08]: Lesson-108.md
+[1.09]: Lesson-109.md
 [1.99]: #199
 [Curriculum Assets]: ../Assets.md
-[Lesson 1.01]: ./Lesson-101.md
-[Lesson 1.02]: ./Lesson-102.md
-[Lesson 1.03]: ./Lesson-103.md
-[Lesson 1.04]: ./Lesson-104.md
-[Lesson 1.05]: ./Lesson-105.md
-[Lesson 1.06]: ./Lesson-106.md
-[Lesson 1.07]: ./Lesson-107.md
-[Lesson 1.08]: ./Lesson-108.md
-[Lesson 1.09]: ./Lesson-109.md
+[Lesson 1.01]: Lesson-101.md
+[Lesson 1.02]: Lesson-102.md
+[Lesson 1.03]: Lesson-103.md
+[Lesson 1.04]: Lesson-104.md
+[Lesson 1.05]: Lesson-105.md
+[Lesson 1.06]: Lesson-106.md
+[Lesson 1.07]: Lesson-107.md
+[Lesson 1.08]: Lesson-108.md
+[Lesson 1.09]: Lesson-109.md
 [Unit 1 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit1/Unit1.pptx
 [Unit 1 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit1/Unit%201%20Word%20Bank.docx
 [WS 1.1.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit1/WS%201.1.1.docx

--- a/curriculum/Unit2/Unit2-Map.md
+++ b/curriculum/Unit2/Unit2-Map.md
@@ -147,32 +147,32 @@ classroom.
 
 
 
-[2.00]: ./Lesson-200.md
-[2.01]: ./Lesson-201.md
-[2.02]: ./Lesson-202.md
-[2.03]: ./Lesson-203.md
-[2.04]: ./Lesson-204.md
-[2.05]: ./Lesson-205.md
-[2.06]: ./Lesson-206.md
-[2.07]: ./Lesson-207.md
-[2.08]: ./Lesson-208.md
-[2.09]: ./Lesson-209.md
-[2.10]: ./Lesson-210.md
-[2.11]: ./Lesson-211.md
+[2.00]: Lesson-200.md
+[2.01]: Lesson-201.md
+[2.02]: Lesson-202.md
+[2.03]: Lesson-203.md
+[2.04]: Lesson-204.md
+[2.05]: Lesson-205.md
+[2.06]: Lesson-206.md
+[2.07]: Lesson-207.md
+[2.08]: Lesson-208.md
+[2.09]: Lesson-209.md
+[2.10]: Lesson-210.md
+[2.11]: Lesson-211.md
 [2.99]: #299
 [Curriculum Assets]: ../Assets.md
-[Lesson 2.00]: ./Lesson-200.md
-[Lesson 2.01]: ./Lesson-201.md
-[Lesson 2.02]: ./Lesson-202.md
-[Lesson 2.03]: ./Lesson-203.md
-[Lesson 2.04]: ./Lesson-204.md
-[Lesson 2.05]: ./Lesson-205.md
-[Lesson 2.06]: ./Lesson-206.md
-[Lesson 2.07]: ./Lesson-207.md
-[Lesson 2.08]: ./Lesson-208.md
-[Lesson 2.09]: ./Lesson-209.md
-[Lesson 2.10]: ./Lesson-210.md
-[Lesson 2.11]: ./Lesson-211.md
+[Lesson 2.00]: Lesson-200.md
+[Lesson 2.01]: Lesson-201.md
+[Lesson 2.02]: Lesson-202.md
+[Lesson 2.03]: Lesson-203.md
+[Lesson 2.04]: Lesson-204.md
+[Lesson 2.05]: Lesson-205.md
+[Lesson 2.06]: Lesson-206.md
+[Lesson 2.07]: Lesson-207.md
+[Lesson 2.08]: Lesson-208.md
+[Lesson 2.09]: Lesson-209.md
+[Lesson 2.10]: Lesson-210.md
+[Lesson 2.11]: Lesson-211.md
 [Poster 2.4]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/Poster%202.4.docx
 [Unit 2 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/Unit2.pptx
 [Unit 2 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit2/Unit%202%20Word%20Bank.docx

--- a/curriculum/Unit3/Unit3-Map.md
+++ b/curriculum/Unit3/Unit3-Map.md
@@ -230,53 +230,53 @@ classroom.
 
 
 
-[3.00]: ./Lesson-300.md
-[3.01]: ./Lesson-301.md
-[3.02]: ./Lesson-302.md
-[3.03]: ./Lesson-303.md
-[3.04]: ./Lesson-304.md
-[3.05]: ./Lesson-305.md
-[3.06]: ./Lesson-306.md
-[3.07]: ./Lesson-307.md
-[3.08]: ./Lesson-308.md
-[3.09]: ./Lesson-309.md
-[3.10]: ./Lesson-310.md
-[3.11]: ./Lesson-311.md
-[3.12]: ./Lesson-312.md
-[3.13]: ./Lesson-313.md
-[3.14]: ./Lesson-314.md
-[3.15]: ./Lesson-315.md
-[3.16]: ./Lesson-316.md
-[3.17]: ./Lesson-317.md
-[3.18]: ./Lesson-318.md
+[3.00]: Lesson-300.md
+[3.01]: Lesson-301.md
+[3.02]: Lesson-302.md
+[3.03]: Lesson-303.md
+[3.04]: Lesson-304.md
+[3.05]: Lesson-305.md
+[3.06]: Lesson-306.md
+[3.07]: Lesson-307.md
+[3.08]: Lesson-308.md
+[3.09]: Lesson-309.md
+[3.10]: Lesson-310.md
+[3.11]: Lesson-311.md
+[3.12]: Lesson-312.md
+[3.13]: Lesson-313.md
+[3.14]: Lesson-314.md
+[3.15]: Lesson-315.md
+[3.16]: Lesson-316.md
+[3.17]: Lesson-317.md
+[3.18]: Lesson-318.md
 [Algorithm for Solving Problems]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Algorithm%20for%20Solving%20Problems.docx
 [Curriculum Assets]: ../Assets.md
 [DeMorgan’s Law]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/DeMorgan%27s%20Law.pptx
 [Equestria]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Map%20of%20Equestria.pptx
 [Frac Calc]: ../Assets.md#fraccalc
-[Lesson 3.00]: ./Lesson-300.md
-[Lesson 3.01]: ./Lesson-301.md
-[Lesson 3.02]: ./Lesson-302.md
-[Lesson 3.03]: ./Lesson-303.md
-[Lesson 3.04]: ./Lesson-304.md
-[Lesson 3.05]: ./Lesson-305.md
-[Lesson 3.06]: ./Lesson-306.md
-[Lesson 3.07]: ./Lesson-307.md
-[Lesson 3.08]: ./Lesson-308.md
-[Lesson 3.09]: ./Lesson-309.md
-[Lesson 3.10]: ./Lesson-310.md
-[Lesson 3.11]: ./Lesson-311.md
-[Lesson 3.12]: ./Lesson-312.md
-[Lesson 3.13]: ./Lesson-313.md
-[Lesson 3.14]: ./Lesson-314.md
-[Lesson 3.15]: ./Lesson-315.md
-[Lesson 3.16]: ./Lesson-316.md
-[Lesson 3.17]: ./Lesson-317.md
-[Lesson 3.18]: ./Lesson-318.md
+[Lesson 3.00]: Lesson-300.md
+[Lesson 3.01]: Lesson-301.md
+[Lesson 3.02]: Lesson-302.md
+[Lesson 3.03]: Lesson-303.md
+[Lesson 3.04]: Lesson-304.md
+[Lesson 3.05]: Lesson-305.md
+[Lesson 3.06]: Lesson-306.md
+[Lesson 3.07]: Lesson-307.md
+[Lesson 3.08]: Lesson-308.md
+[Lesson 3.09]: Lesson-309.md
+[Lesson 3.10]: Lesson-310.md
+[Lesson 3.11]: Lesson-311.md
+[Lesson 3.12]: Lesson-312.md
+[Lesson 3.13]: Lesson-313.md
+[Lesson 3.14]: Lesson-314.md
+[Lesson 3.15]: Lesson-315.md
+[Lesson 3.16]: Lesson-316.md
+[Lesson 3.17]: Lesson-317.md
+[Lesson 3.18]: Lesson-318.md
 [Operator Precedence]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Operator%20Precedence.pptx
 [Poster 3.16.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Poster%203.16.1.pdf
 [Poster 3.16.2]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Poster%203.16.2.pdf
-[Test 2 Guide]: ./Test-2-Guide.md
+[Test 2 Guide]: Test-2-Guide.md
 [Unit 3 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Unit3.pptx
 [Unit 3 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/Unit%203%20Word%20Bank.docx
 [WS 3.10]:  https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit3/WS%203.10.docx

--- a/curriculum/Unit4/Unit4-Map.md
+++ b/curriculum/Unit4/Unit4-Map.md
@@ -188,29 +188,29 @@ classroom.
 
 
 
-[4.00]: ./Lesson-400.md
-[4.01]: ./Lesson-401.md
-[4.02]: ./Lesson-402.md
-[4.03]: ./Lesson-403.md
-[4.04]: ./Lesson-404.md
-[4.05]: ./Lesson-405.md
-[4.06]: ./Lesson-406.md
-[4.07]: ./Lesson-407.md
-[4.08]: ./Lesson-408.md
-[4.09]: ./Lesson-409.md
-[4.10]: ./Lesson-410.md
+[4.00]: Lesson-400.md
+[4.01]: Lesson-401.md
+[4.02]: Lesson-402.md
+[4.03]: Lesson-403.md
+[4.04]: Lesson-404.md
+[4.05]: Lesson-405.md
+[4.06]: Lesson-406.md
+[4.07]: Lesson-407.md
+[4.08]: Lesson-408.md
+[4.09]: Lesson-409.md
+[4.10]: Lesson-410.md
 [Curriculum Assets]: ../Assets.md
-[Lesson 4.00]: ./Lesson-400.md
-[Lesson 4.01]: ./Lesson-401.md
-[Lesson 4.02]: ./Lesson-402.md
-[Lesson 4.03]: ./Lesson-403.md
-[Lesson 4.04]: ./Lesson-404.md
-[Lesson 4.05]: ./Lesson-405.md
-[Lesson 4.06]: ./Lesson-406.md
-[Lesson 4.07]: ./Lesson-407.md
-[Lesson 4.08]: ./Lesson-408.md
-[Lesson 4.09]: ./Lesson-409.md
-[Lesson 4.10]: ./Lesson-410.md
+[Lesson 4.00]: Lesson-400.md
+[Lesson 4.01]: Lesson-401.md
+[Lesson 4.02]: Lesson-402.md
+[Lesson 4.03]: Lesson-403.md
+[Lesson 4.04]: Lesson-404.md
+[Lesson 4.05]: Lesson-405.md
+[Lesson 4.06]: Lesson-406.md
+[Lesson 4.07]: Lesson-407.md
+[Lesson 4.08]: Lesson-408.md
+[Lesson 4.09]: Lesson-409.md
+[Lesson 4.10]: Lesson-410.md
 [Magpie Chatbot Lab]: ../Assets.md#magpie
 [Poster 4.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/Poster%204.1.pptx
 [Poster 4.2]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit4/Poster%204.2.pptx

--- a/curriculum/Unit5/Unit5-Map.md
+++ b/curriculum/Unit5/Unit5-Map.md
@@ -188,24 +188,24 @@ classroom.
 - **PP** — Programming Project (in the textbook)
 
 
-[Picture Lab]: Assets.md#picturelab
-[5.00]: ./Lesson-500.md
-[5.01]: ./Lesson-501.md
-[5.02]: ./Lesson-502.md
-[5.03]: ./Lesson-503.md
-[5.04]: ./Lesson-504.md
-[5.05]: ./Lesson-505.md
-[5.06]: ./Lesson-506.md
-[5.07]: ./Lesson-507.md
+[5.00]: Lesson-500.md
+[5.01]: Lesson-501.md
+[5.02]: Lesson-502.md
+[5.03]: Lesson-503.md
+[5.04]: Lesson-504.md
+[5.05]: Lesson-505.md
+[5.06]: Lesson-506.md
+[5.07]: Lesson-507.md
 [Curriculum Assets]: ../Assets.md
-[Lesson 5.00]: ./Lesson-500.md
-[Lesson 5.01]: ./Lesson-501.md
-[Lesson 5.02]: ./Lesson-502.md
-[Lesson 5.03]: ./Lesson-503.md
-[Lesson 5.04]: ./Lesson-504.md
-[Lesson 5.05]: ./Lesson-505.md
-[Lesson 5.06]: ./Lesson-506.md
-[Lesson 5.07]: ./Lesson-507.md
+[Lesson 5.00]: Lesson-500.md
+[Lesson 5.01]: Lesson-501.md
+[Lesson 5.02]: Lesson-502.md
+[Lesson 5.03]: Lesson-503.md
+[Lesson 5.04]: Lesson-504.md
+[Lesson 5.05]: Lesson-505.md
+[Lesson 5.06]: Lesson-506.md
+[Lesson 5.07]: Lesson-507.md
+[Picture Lab]: Assets.md#picturelab
 [Unit 5 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/Unit5.pptx
 [Unit 5 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/Unit%205%20Word%20Bank.docx
 [WS 5.1.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit5/WS%205.1.1.pdf

--- a/curriculum/Unit6/Unit6-Map.md
+++ b/curriculum/Unit6/Unit6-Map.md
@@ -185,36 +185,36 @@ classroom.
 - **PP** — Programming Project (in the textbook)
 
 
-[6.00]: ./Lesson-600.md
+[6.00]: Lesson-600.md
+[6.01]: Lesson-601.md
+[6.02]: Lesson-602.md
+[6.03]: Lesson-603.md
+[6.04]: Lesson-604.md
+[6.05]: Lesson-605.md
+[6.06]: Lesson-606.md
+[6.07]: Lesson-607.md
+[6.08]: Lesson-608.md
+[6.09]: Lesson-609.md
+[Curriculum Assets]: ../Assets.md
+[Example 6.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Example%206.1.jpg
+[Lesson 6.00]: Lesson-600.md
+[Lesson 6.01]: Lesson-601.md
+[Lesson 6.02]: Lesson-602.md
+[Lesson 6.03]: Lesson-603.md
+[Lesson 6.04]: Lesson-604.md
+[Lesson 6.05]: Lesson-605.md
+[Lesson 6.06]: Lesson-606.md
+[Lesson 6.07]: Lesson-607.md
+[Lesson 6.08]: Lesson-608.md
+[Lesson 6.09]: Lesson-609.md
+[Poster 6.3]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Poster%206.3.pptx
+[Poster 6.6]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Poster%206.6.pptx
+[Test 5 Guide]: Test-5-Guide.md
 [Text Excel Student Guide A]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Text%20Excel%20A%20Student%20Guide.docx
 [Text Excel Student Guide B]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Text%20Excel%20B%20Student%20Guide.docx
 [Text Excel Student Guide C]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Text%20Excel%20C%20Student%20Guide.docx
 [Text Excel Teacher Guide]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Text%20Excel%20Teacher%20Guide.docx
 [Text Excel]: Assets.md#textexcel
-[6.01]: ./Lesson-601.md
-[6.02]: ./Lesson-602.md
-[6.03]: ./Lesson-603.md
-[6.04]: ./Lesson-604.md
-[6.05]: ./Lesson-605.md
-[6.06]: ./Lesson-606.md
-[6.07]: ./Lesson-607.md
-[6.08]: ./Lesson-608.md
-[6.09]: ./Lesson-609.md
-[Curriculum Assets]: ../Assets.md
-[Example 6.1]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Example%206.1.jpg
-[Lesson 6.00]: ./Lesson-600.md
-[Lesson 6.01]: ./Lesson-601.md
-[Lesson 6.02]: ./Lesson-602.md
-[Lesson 6.03]: ./Lesson-603.md
-[Lesson 6.04]: ./Lesson-604.md
-[Lesson 6.05]: ./Lesson-605.md
-[Lesson 6.06]: ./Lesson-606.md
-[Lesson 6.07]: ./Lesson-607.md
-[Lesson 6.08]: ./Lesson-608.md
-[Lesson 6.09]: ./Lesson-609.md
-[Poster 6.3]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Poster%206.3.pptx
-[Poster 6.6]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Poster%206.6.pptx
-[Test 5 Guide]: ./Test-5-Guide.md
 [Unit 6 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Unit6.pptx
 [Unit 6 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/Unit%206%20Word%20Bank.docx
 [WS 6.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit6/WS%206.1.docx

--- a/curriculum/Unit7/Unit7-Map.md
+++ b/curriculum/Unit7/Unit7-Map.md
@@ -228,19 +228,19 @@ classroom.
 - **PP** — Programming Project (in the textbook)
 
 
-[7.00]: ./Lesson-700.md
-[7.01]: ./Lesson-701.md
-[7.02]: ./Lesson-702.md
-[7.03]: ./Lesson-703.md
-[7.04]: ./Lesson-704.md
+[7.00]: Lesson-700.md
+[7.01]: Lesson-701.md
+[7.02]: Lesson-702.md
+[7.03]: Lesson-703.md
+[7.04]: Lesson-704.md
 [Curriculum Assets]: ../Assets.md
-[Lesson 7.00]: ./Lesson-700.md
-[Lesson 7.01]: ./Lesson-701.md
-[Lesson 7.02]: ./Lesson-702.md
-[Lesson 7.03]: ./Lesson-703.md
-[Lesson 7.04]: ./Lesson-704.md
-[Test 6 Guide]: ./Test-6-Guide.md
+[Elevens Lab]: Assets.md#elevens
+[Lesson 7.00]: Lesson-700.md
+[Lesson 7.01]: Lesson-701.md
+[Lesson 7.02]: Lesson-702.md
+[Lesson 7.03]: Lesson-703.md
+[Lesson 7.04]: Lesson-704.md
+[Test 6 Guide]: Test-6-Guide.md
 [Unit 7 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit7/Unit7.pptx
 [Unit 7 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit7/Unit%207%20Word%20Bank.docx
 [WS 7.1]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit7/WS%207.1.docx
-[Elevens Lab]: Assets.md#elevens

--- a/curriculum/Unit8/Unit8-Map.md
+++ b/curriculum/Unit8/Unit8-Map.md
@@ -107,25 +107,25 @@ classroom.
 
 
 [8.00]: Unit8/Lesson-800.md
-[Teacher Demo 8.3]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit8/Teacher%20Demo%208.3.docx
-[8.01]: ./Lesson-801.md
-[8.02]: ./Lesson-802.md
-[8.03]: ./Lesson-803.md
-[8.04]: ./Lesson-804.md
-[8.05]: ./Lesson-805.md
-[8.06]: ./Lesson-806.md
+[8.01]: Lesson-801.md
+[8.02]: Lesson-802.md
+[8.03]: Lesson-803.md
+[8.04]: Lesson-804.md
+[8.05]: Lesson-805.md
+[8.06]: Lesson-806.md
 [8.07]: #807
-[8.08]: ./Lesson-808.md
+[8.08]: Lesson-808.md
 [Curriculum Assets]: ../Assets.md
-[Lesson 8.00]: ./Lesson-800.md
-[Lesson 8.01]: ./Lesson-801.md
-[Lesson 8.02]: ./Lesson-802.md
-[Lesson 8.03]: ./Lesson-803.md
-[Lesson 8.04]: ./Lesson-804.md
-[Lesson 8.05]: ./Lesson-805.md
-[Lesson 8.06]: ./Lesson-806.md
-[Lesson 8.08]: ./Lesson-808.md
+[Lesson 8.00]: Lesson-800.md
+[Lesson 8.01]: Lesson-801.md
+[Lesson 8.02]: Lesson-802.md
+[Lesson 8.03]: Lesson-803.md
+[Lesson 8.04]: Lesson-804.md
+[Lesson 8.05]: Lesson-805.md
+[Lesson 8.06]: Lesson-806.md
+[Lesson 8.08]: Lesson-808.md
+[Quiz 8.5]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit8/Quiz%208.5.docx
+[Teacher Demo 8.3]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit8/Teacher%20Demo%208.3.docx
 [Unit 8 Slides]:    https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit8/Unit8.pptx
 [Unit 8 Word Bank]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit8/Unit%208%20Word%20Bank.docx
 [WS 8.3]:   https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit8/WS%208.3.docx
-[Quiz 8.5]: https://raw.githubusercontent.com/TEALSK12/apcsa-public/master/curriculum/Unit8/Quiz%208.5.docx

--- a/curriculum/Unit9/Unit9-Map.md
+++ b/curriculum/Unit9/Unit9-Map.md
@@ -14,6 +14,6 @@ Unit 9: AP Test Review (3 weeks)
 
 
 
-[9.00]: ./Lesson-900.md
+[9.00]: Lesson-900.md
 [Curriculum Assets]: ../Assets.md
-[Lesson 9.00]: ./Lesson-900.md
+[Lesson 9.00]: Lesson-900.md


### PR DESCRIPTION
Apparently GitBook understands "./foo" links to point back to the source
GitHub repo for some reason. These changes drop the leading "./" from
links.