### PR TITLE
Fixed Broken Link to Curriculum Assets

### DIFF
--- a/curriculum/Unit5-Map-CB.md
+++ b/curriculum/Unit5-Map-CB.md
@@ -217,7 +217,7 @@ chronological order. The order has been adapted to follow the College Board AP C
 [5.06a]: Unit5/Lesson-506a.md
 [5.06b]: Unit5/Lesson-506b.md
 [5.07]: Unit5/Lesson-507.md
-[Curriculum Assets]: ../Assets.md
+[Curriculum Assets]: Assets.md
 [6.00]: Unit6/Lesson-600.md
 
 


### PR DESCRIPTION
A teacher reported that the Curriculum Assets link in CBUnit5 is broken. 