### PR TITLE
fix old curriculum map link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,7 @@ We have provided classroom management tips and engagement tips for TEALS volunte
 the classroom setting. Experienced teachers and volunteers will likely choose to skip such details
 and focus on the step-by-step lecture notes.
 
-You may browse the [Curriculum Map][] for an overview of the pacing, objectives, and assessments.
+You may browse the [Curriculum Map](https://tealsk12.github.io/apcsa-public/SUMMARY-Endorsed.md) for an overview of the pacing, objectives, and assessments.
 
 For TEALS schools in BC, Canada, please see [Aligning TEALS APCSA Teaching Resources with the BC Curriculum](CA-README.md.html).
 


### PR DESCRIPTION
The curriculum map was taking me to the deprecated gitbook copy.  This PR updates it to the new github pages link.